### PR TITLE
Nostr as transport protocol

### DIFF
--- a/24.md
+++ b/24.md
@@ -1,0 +1,16 @@
+BDS-24
+======
+
+Nostr-based transport protocol
+-------------------------------
+
+`draft` `mandatory` `author:tiero`
+
+This BDS defines how Bits wallets communicate with Bits Service Providers using [Nostr](https://github.com/nostr-protocol/nostr) relays. 
+
+## Rationale
+
+Exposing your own IP address and/or owning a FQDN make Bits Service Providers vulenerable to DoS attacks and regulatory capture.
+
+## Specification
+ TBD


### PR DESCRIPTION
I am squatting the BDS-24 for hosting the proposal for using Nostr as a transport protocol for bits wallets <> bits SP communication.